### PR TITLE
fix: aria-role for section tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <span class="main__subscription-duration">per month</span>
       </h3>
       <p class="main__description">Full access for less than &dollar;1 a day</p>
-      <section role="button" class="main__sign-up-button">Sign Up</section>
+      <div role="button" class="main__sign-up-button">Sign Up</div>
     </section>
     <section class="main__third-section">
       <h2 class="main__third-heading">Why Us</h2>


### PR DESCRIPTION
BUG:
- Section elements do not support aria `role=button`
- It causes accessibility & html validation issues

HOW WE FIXED:
- Fixed by **refractoring** the `section` element with `div` element
- Because div support all type aria roles without any issues